### PR TITLE
Fix CSV header usage in index builder

### DIFF
--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -26,9 +26,9 @@ LABELS_FILE = "resources/labels.json"
 labels = []
 with open(INPUT_CSV, newline='', encoding='utf-8') as f:
     reader = csv.DictReader(f)
-    # Очакваме колонка "surface_form"
+    # Очакваме колонка "form"
     for row in reader:
-        labels.append(row["surface_form"])
+        labels.append(row["form"])
 
 print(f"Loaded {len(labels)} surface forms.")
 


### PR DESCRIPTION
## Summary
- load the `form` column when reading `resources/surface_forms.csv`
- update comment to match the new header

## Testing
- `python3 scripts/build_index.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python3 - <<'EOF'
import csv
with open('resources/surface_forms.csv', newline='', encoding='utf-8') as f:
    reader = csv.DictReader(f)
    labels = [row['form'] for row in reader]
print('count', len(labels))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685918688e80832bbd1c76c6f3eca1c6