### PR TITLE
Add path existence check in evaluate.py

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -43,7 +43,16 @@ def _load_file(fp: Path):
 def load_ann(path):
     """Load annotations from a directory or a single file."""
     path = Path(path)
-    files = [path] if path.is_file() else list(path.glob("*.json"))
+    if not path.exists():
+        raise FileNotFoundError(f"Annotations path '{path}' does not exist")
+
+    if path.is_file():
+        files = [path]
+    else:
+        files = list(path.glob("*.json"))
+        if not files:
+            print(f"Warning: no JSON files found in {path}")
+            return set()
 
     res = set()
     for fp in files:


### PR DESCRIPTION
## Summary
- raise FileNotFoundError when the annotations path doesn't exist
- warn when no `.json` files are found

## Testing
- `python evaluate.py -h`
- `python -m py_compile evaluate.py`


------
https://chatgpt.com/codex/tasks/task_e_685964334bfc832b8cce7eeb185cba66