### PR TITLE
Fix build index documentation

### DIFF
--- a/scripts/extract_surface_forms.py
+++ b/scripts/extract_surface_forms.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """
-build_index.py
+Generate embeddings for ontology surface forms and build a FAISS index.
 
-Чете surface_forms.csv, вика /v1/embeddings на LM Studio,
-нормализира векторите и строи FAISS индекс.
+The script reads ``resources/surface_forms.csv``, fetches embeddings from
+LM Studio's ``/v1/embeddings`` API, normalizes the vectors for cosine
+similarity, builds a FAISS index and writes both the index and a JSON
+file with the original forms and their URIs.
 """
 
 import requests, json, csv, os
@@ -30,7 +32,7 @@ resp.raise_for_status()
 vectors = np.array([d["embedding"] for d in resp.json()["data"]], dtype="float32")
 
 # --- 3. нормализация + индекс ---
-faiss.normalize_L2(vectors)                                    # cosine sim  :contentReference[oaicite:1]{index=1}
+faiss.normalize_L2(vectors)                                    # cosine sim
 dim   = vectors.shape[1]
 index = faiss.IndexFlatIP(dim)
 index.add(vectors)


### PR DESCRIPTION
## Summary
- update `extract_surface_forms.py` docstring with correct description
- remove stray `:contentReference[...]` fragment

## Testing
- `python3 -m py_compile scripts/extract_surface_forms.py`


------
https://chatgpt.com/codex/tasks/task_e_68596437d4b4832b8514975844e8bd5e