### PR TITLE
Add sample output and improve evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Run the following steps to process a text file and evaluate the results:
    ```bash
    python evaluate.py output resources/gold.json
    ```
+   Make sure the `output/` directory contains JSON files in the form
+   `{ "doc": "...", "matches": [...] }`. Files that do not contain
+   `start`, `end` and `uri` fields will be ignored during evaluation.
 
 `evaluate.py` accepts either a directory of JSON files or a single JSON
 file for both the predictions and the gold annotations.

--- a/evaluate.py
+++ b/evaluate.py
@@ -36,7 +36,15 @@ def _load_file(fp: Path):
 
     res = set()
     for a in items:
-        res.add((a.get("doc", ""), a["start"], a["end"], a["uri"]))
+        try:
+            start = int(a["start"])
+            end = int(a["end"])
+            uri = a["uri"]
+        except KeyError:
+            # skip entries that do not have the required fields
+            print(f"Warning: skipping invalid annotation in {fp.name}: {a}")
+            continue
+        res.add((a.get("doc", ""), start, end, uri))
     return res
 
 

--- a/output/Barolo.json
+++ b/output/Barolo.json
@@ -1,0 +1,29 @@
+{
+  "doc": "Barolo.txt",
+  "matches": [
+    {
+      "start": 72,
+      "end": 76,
+      "surface": "wine",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Wine"
+    },
+    {
+      "start": 192,
+      "end": 196,
+      "surface": "wine",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Wine"
+    },
+    {
+      "start": 122,
+      "end": 128,
+      "surface": "region",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Region"
+    },
+    {
+      "start": 12,
+      "end": 15,
+      "surface": "red",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Red"
+    }
+  ]
+}

--- a/output/Chateau_Margaux.json
+++ b/output/Chateau_Margaux.json
@@ -1,0 +1,59 @@
+{
+  "doc": "Chateau_Margaux.txt",
+  "matches": [
+    {
+      "start": 21,
+      "end": 25,
+      "surface": "wine",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Wine"
+    },
+    {
+      "start": 246,
+      "end": 250,
+      "surface": "wine",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Wine"
+    },
+    {
+      "start": 49,
+      "end": 55,
+      "surface": "region",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Region"
+    },
+    {
+      "start": 8,
+      "end": 15,
+      "surface": "Margaux",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Margaux"
+    },
+    {
+      "start": 40,
+      "end": 55,
+      "surface": "Bordeaux region",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#BordeauxRegion"
+    },
+    {
+      "start": 217,
+      "end": 223,
+      "surface": "Merlot",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Merlot"
+    },
+    {
+      "start": 86,
+      "end": 104,
+      "surface": "Cabernet Sauvignon",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#CabernetSauvignon"
+    },
+    {
+      "start": 186,
+      "end": 204,
+      "surface": "Cabernet Sauvignon",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#CabernetSauvignon"
+    },
+    {
+      "start": 40,
+      "end": 48,
+      "surface": "Bordeaux",
+      "uri": "http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#Bordeaux"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add example annotation outputs for Barolo and Chateau Margaux
- make `evaluate.py` skip invalid JSON entries instead of crashing
- document expected output format in README

## Testing
- `python -m py_compile evaluate.py scripts/*.py`
- `python evaluate.py output resources/gold.json`

------
https://chatgpt.com/codex/tasks/task_e_685ff2715620832b83e180c4cf8d3a71